### PR TITLE
Create regular object for return value

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36,7 +36,7 @@
         <emu-alg>
           1. Let _C_ be *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
-          1. Let _obj_ be OrdinaryObjectCreate(*null*).
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, "promise", _promiseCapability_.[[Promise]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, "resolve", _promiseCapability_.[[Resolve]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, "reject", _promiseCapability_.[[Reject]]).


### PR DESCRIPTION
The return value was previously a prototype-less object (`Object.create(null)`), but I don't think there's a need for that? The array-grouping proposal chose to use one because the return object could have arbitrary keys (and possibly missing keys that conflict with builtin API names). But the deferred object here has a defined shape, so that doesn't apply.