### PR TITLE
Array Deconstructing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ This is boilerplate code that is very frequently re-written by developers. This 
 const { promise, resolve, reject } = Promise.withResolvers();
 ```
 
+To reduce boiler plate when renaming these functions, array destructuring is allowed as the result of calling `withResolvers` would be iterable.
+
+```js
+const [readFile, resolveReadFile, rejectReadFile] = Promise.withResolvers();
+```
+
+
 This method or something like it may be known to some committee members under the name `defer` or `deferred`, names also sometimes applied to utility functions in the ecosystem. This proposal adopts a more descriptive name for the benefit of users who may not be familiar with those historical functions.
 
 ## Existing implementations

--- a/polyfills.js
+++ b/polyfills.js
@@ -1,6 +1,12 @@
 export function withResolvers() {
 	if (!this) throw new TypeError("Promise.withResolvers called on non-object")
-	const out = {}
+	const out = {
+		*[Symbol.iterator](){
+     			yield this.promise;
+     			yield this.resolve;
+     			yield this.reject;
+  		}
+	}
 	out.promise = new this((resolve_, reject_) => {
 		out.resolve = resolve_
 		out.reject = reject_

--- a/spec.html
+++ b/spec.html
@@ -37,7 +37,7 @@
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, "[Symbol.iterator]", _promiseCapability_.[[Iterator]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, %Symbol.iterator%, _promiseCapability_.[[Iterator]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, "promise", _promiseCapability_.[[Promise]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, "resolve", _promiseCapability_.[[Resolve]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, "reject", _promiseCapability_.[[Reject]]).

--- a/spec.html
+++ b/spec.html
@@ -37,6 +37,7 @@
           1. Let _C_ be the *this* value.
           1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
           1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, "[Symbol.iterator]", _promiseCapability_.[[Iterator]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, "promise", _promiseCapability_.[[Promise]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, "resolve", _promiseCapability_.[[Resolve]]).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, "reject", _promiseCapability_.[[Reject]]).


### PR DESCRIPTION
Make result of calling `withResolvers` iterable as to support array deconstructing.
[Relevant discussion](https://github.com/tc39/proposal-promise-with-resolvers/issues/16)

Note: this will likely be rejected, but it's good to have the option as discussed above.